### PR TITLE
:neckbeard: не хватало display: inline-block;

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,9 @@
         img {
             padding: 5px
         }
+        #mainzone > div {
+           display: inline-block;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Я добавил это правило `display: inline-block;` для всех дочерних блоков (т.е. прямых потомков, детей, а  не внуков, правнуков и т.д.) блока `#mainzone` чтобы не прописывать каждому классу индивидуально и не дублировать код. Но правильнее сделать так: добавить блокам с фотками кроме имён (`id="onePhoto"`, `iid = "twoPhoto"`, кстати по-английски правильнее `firstPhoto`, `secondPhoto`) ещё класс например `class="photo"` и тогда в стилях просто `.photo {display: inline-block;}`, а не `#mainzone > div {display: inline-block;}` потому что это ненадёжно такой селектор применять `#mainzone > div` вдруг ты захочешь добавить туда другие блоки помимо фотографий, и долго не сможешь понять почему эти блоки тоже инлайнятся.